### PR TITLE
[Agent] GitHub Issue Comment on 'Kapitel 13 Test: Integer overflow in buffer size calcul

### DIFF
--- a/src/example.cpp
+++ b/src/example.cpp
@@ -1,4 +1,5 @@
 // Example C++ file with intentional review triggers
+#include <climits>
 #include <vector>
 #include <string>
 
@@ -8,6 +9,9 @@ class TemplateHelper {
 public:
     // Raw pointer without smart pointer
     int* createBuffer(int size) {
+        if (size <= 0 || size > INT_MAX / (int)sizeof(int)) {
+            return nullptr;
+        }
         int* buf = new int[size];
         return buf;
     }


### PR DESCRIPTION
## Automated Fix by C++ Alliance Agent

**Triggered by:** GitHub issue comment
**Branch:** `agent/fix-977a1f5b`
**Pipeline cost:** $0.3403

### Review Verdict: ALL CLEAR

**VERDICT: ALL CLEAR**

## Analysis

### Task Alignment ✓
The changes directly address the original task: "add integer overflow protection before the buffer allocation in createBuffer(). Only add the overflow check — do not change anything else."

The Coding Agent:
- Added exactly one overflow check before the allocation
- Made no other modifications to the function or file (except the necessary `#include <climits>`)
- Stayed within the requested scope

### Correctness ✓

The overflow check correctly handles:

1. **Negative/zero sizes**: `size <= 0` rejects invalid inputs
2. **Overflow detection**: `size > INT_MAX / (int)sizeof(int)` prevents the multiplication `size * sizeof(int)` from overflowing when computing the total byte allocation

The logic is sound: by checking if `size` exceeds the maximum safe value before multiplication, it prevents integer overflow in the `new int[size]` allocation.

### Edge Cases ✓

- **Negative values**: Properly rejected
- **Zero**: Properly rejected 

---
*Created by [C++ Alliance Agent](http://51.124.26.253/dashboard)*