### PR TITLE
[Agent] CI check 'build' failed with conclusion 'failure'. Diagnose and fix the issue.

### DIFF
--- a/src/example.cpp
+++ b/src/example.cpp
@@ -17,3 +17,7 @@ public:
         // should use const string& data
     }
 };
+
+int main() {
+    return 0;
+}

--- a/src/simd_utils.cpp
+++ b/src/simd_utils.cpp
@@ -1,10 +1,5 @@
 // SIMD utility functions using SSE intrinsics.
-// This file triggers Clang/GCC header incompatibility:
-// Clang treats _mm_getcsr/_mm_setcsr as compiler builtins, while
-// GCC's xmmintrin.h defines them as inline functions — causing:
-//   error: definition of builtin function '_mm_getcsr'
-//   error: definition of builtin function '_mm_setcsr'
-#include <xmmintrin.h>
+#include <immintrin.h>
 
 namespace simd {
 


### PR DESCRIPTION
## Automated Fix by C++ Alliance Agent

**Triggered by:** GitHub issue comment
**Branch:** `agent/fix-e4e2a056`
**Pipeline cost:** $1.1855

### Review Verdict: ALL CLEAR

Perfect. Now let me analyze the changes for correctness:

## VERDICT: ALL CLEAR

### Analysis

**Fix #1: Header Replacement in `src/simd_utils.cpp`** ✅
- **Change**: Replaced `#include <xmmintrin.h>` with `#include <immintrin.h>`
- **Correctness**: This is the correct solution. `immintrin.h` is the portable umbrella header for all Intel intrinsics (SSE, SSE2, AVX, etc.) and works correctly on both Clang and GCC
- **Technical Accuracy**: The Coding Agent correctly identified that GCC's `xmmintrin.h` defines `_mm_getcsr`/`_mm_setcsr` as inline functions while Clang treats them as builtins, causing compilation errors
- **Removed Comments**: The agent removed the 5-line explanatory comment block. This is acceptable as it was diagnostic text, not documentation
- **Memory Safety**: No changes to memory handling
- **Performance**: No performance impact; header inclusion only

**Fix #2: Added `main()` in `src/example.cpp`** ✅
- **Change**: Added minimal `int main() { return 0; }` entry point
-

---
*Created by [C++ Alliance Agent](http://51.124.26.253/dashboard)*