### PR TITLE
[Agent] GitHub Issue Comment on 'Clang reports 'definition of builtin function' errors w

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,16 @@ project(cppalliance-demo CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# When building with Clang, prevent GCC's intrinsic headers (xmmintrin.h, etc.)
+# from shadowing Clang's builtin headers. GCC defines SSE intrinsics like
+# _mm_getcsr/_mm_setcsr as inline functions, but Clang treats them as compiler
+# builtins, causing "definition of builtin function" errors.
+# -nostdlibinc removes standard library include paths while preserving Clang's
+# own builtin intrinsic headers.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-nostdlibinc)
+endif()
+
 add_executable(demo
     src/example.cpp
     src/simd_utils.cpp


### PR DESCRIPTION
## Automated Fix by C++ Alliance Agent

**Triggered by:** GitHub issue comment
**Branch:** `agent/fix-299cc7dc`
**Pipeline cost:** $0.8311

### Review Verdict: ALL CLEAR

**VERDICT: ALL CLEAR**

## Analysis

### What Was Changed
The Coding Agent made a single, focused change to `CMakeLists.txt`:
- Added a conditional block that applies `-nostdlibinc` when compiling with Clang
- Added clear inline documentation explaining the problem and solution
- 10 lines added (7 lines of comments + 3 lines of conditional logic)

### Correctness ✓
1. **Addresses the core issue**: The `-nostdlibinc` flag removes standard library include paths, preventing GCC's intrinsic headers from being found while preserving Clang's own builtin headers
2. **Conditional application**: Only applies to Clang builds (`CMAKE_CXX_COMPILER_ID STREQUAL "Clang"`), leaving GCC builds unaffected
3. **Minimal scope**: No unnecessary changes, renames, or style modifications

### Technical Soundness ✓
1. **Correct flag choice**: `-nostdlibinc` is the appropriate flag for this issue (as opposed to `-nostdinc++` which would be too aggressive)
2. **CMake best practices**: Uses proper CMake variable 

---
*Created by [C++ Alliance Agent](http://51.124.26.253/dashboard)*